### PR TITLE
otsu thresholding

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SDPSymmetryReduction"
 uuid = "56ed78d6-6c87-4b01-a4f7-e143c302c7a0"
 authors = ["Daniel Brosch <Daniel.Brosch@outlook.com> and contributors"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/diagonalize.jl
+++ b/src/diagonalize.jl
@@ -17,7 +17,7 @@ function check_block_sizes(T::Type{<:Complex}, Q, P::AbstractPartition, verbose:
         @error "Dimension mismatch over for $T:" (final_dim, block_sizes) expedcted_dim = dim(P)
         throw(DimensionMismatch("""Decomposition failed potentially due to
         * Rounding error (try different epsilons and/or try again) or
-        * Unknow reason, please consider submitting an issue.
+        * Unknown reason, please consider submitting an issue.
          """))
     end
 end

--- a/src/eigen_decomposition.jl
+++ b/src/eigen_decomposition.jl
@@ -70,6 +70,73 @@ function block(A::AbstractMatrix, es1::EigenSpace, es2::EigenSpace)
     return Qi' * A * Qj
 end
 
+"""
+    log_histogram(X, num_bins::Integer; atol)
+
+Compute a logarithmically spaced histogram for the absolute values in `X`.
+
+The bin edges are determined using an exponential scale between the smallest
+and largest absolute values in `X`, with a lower bound enforced by `atol`.
+
+Returns the number of elements in each bin and the logarithmically spaced bin edges.
+"""
+function log_histogram(X, num_bins::Integer; atol)
+    # Determine bin edges
+    (min_val, max_val) = extrema(abs, X)
+    min_val = ifelse(min_val < atol, atol, min_val)
+    @assert min_val > 0
+    bin_edges = exp.(range(log(min_val), log(max_val), length=num_bins + 1))
+
+    # Count elements in each bin
+    counts = zeros(Int, num_bins)
+    for x in X
+        k = something(findfirst(b -> b > x, bin_edges), num_bins + 1) - 1
+        bin_index = clamp(k, 1, num_bins)
+        counts[bin_index] += 1
+    end
+    return counts, bin_edges
+end
+
+"""
+    otsu_threshold(X::AbstractArray; atol)
+
+Return a scalar threshold value that separates the entries of `X` into two classes.
+
+The computation is based on Otsu-based thresholding. The method maximizes the
+variance between two classes in a histogram representation of `norms`,
+determining an optimal binarization threshold.
+
+The methods assumes a logarithmic histogram over orders of magnitude spanned by
+the element type of `X`.
+"""
+function otsu_threshold(X::AbstractArray; atol)
+    # consider log histogram over orders of magnitude spanned by norms eltype:
+    n_bins = max(ceil(Int, -log10(eps(real(eltype(X))))), 4) # at least 4 bins
+    counts, edges = log_histogram(X, n_bins; atol=atol)
+
+    # Otsu binarization maximizing variance between classes
+    pdf = counts ./ sum(counts)
+    ω = cumsum(pdf)
+    µᵒ = cumsum(log.(@view(edges[begin:end-1])) .* pdf)
+    μᵀ = µᵒ[end]
+
+    σ² = @. (μᵀ * ω - µᵒ)^2 / (ω * (1 - ω))
+
+    # µᵇ = µᵀ .- reverse(µᵒ)
+    # σ²log = ω .* (µᵒ .- µᵀ) .^ 2 .+
+    # (1 .- ω) .* (µᵇ .- µᵀ) .^ 2
+
+    k = argmax(@view σ²[begin:end-1])
+    # klog = argmax(σ²log[begin:end-1])
+    # if k ≠ klog
+    #     @info counts
+    #     @info σ²log
+    #     @info σ²
+    #     @info (k, klog)
+    # end
+    threshold = edges[k+1]
+    return threshold
+end
 struct InvalidDecompositionField <: Exception
     requested
     found
@@ -100,6 +167,32 @@ function __isconsistent(K)
 end
 
 """
+    block_norms(Q′AQ::AbstractMatrix, eigdec::EigenDecomposition, p=2)
+
+Compute the norms of block endomorphism `Q′AQ` with respect to the eigenspaces `eigdec`.
+
+The function returns a symmetric matrix where the `(i, j)` entry represents the
+`p`-norm of the block corresponding to eigenspaces `i` and `j`
+"""
+function block_norms(Q′AQ::AbstractMatrix, eigdec::EigenDecomposition, p=2)
+    neigspaces = length(eigdec)
+    T = real(eltype(Q′AQ))
+    end_norm = zeros(T, neigspaces, neigspaces)
+    for i in 1:neigspaces
+        Ei = eigdec[i]
+        for j in i:neigspaces # we want the diagonals
+            Ej = eigdec[j]
+            if dim(Ei) ≠ dim(Ej)
+                end_norm[i, j] = end_norm[j, i] = zero(T)
+            else
+                end_norm[i, j] = end_norm[j, i] = norm(@view(Q′AQ[Ei, Ej]), p)
+            end
+        end
+    end
+    return end_norm
+end
+
+"""
     isomorphism_partition(ed::EigenDecomposition, A::AbstractMatrix[; atol])
 Partition eigen-subspaces of `ed` into isomorphism classes based on a generic element `A`.
 
@@ -108,14 +201,16 @@ Computes partition `K` of Murota et al. as defined in **Algorithm 4.1**, Step 3.
 function isomorphism_partition(eigdec::EigenDecomposition, A::AbstractMatrix; atol=1e-12 * size(A, 1))
     Q = eigdec.vectors
     Q′AQ = Q' * A * Q
+    end_infnorm = block_norms(Q′AQ, eigdec, Inf)
+    threshold = otsu_threshold(end_infnorm, atol=atol)
 
     neigspaces = length(eigdec)
     K = IntDisjointSets(neigspaces) # tracks the merging of eigenspaces
     for i in 1:neigspaces
-        Ei = eigdec[i]
         for j in (i+1):neigspaces
-            Ej = eigdec[j]
-            if norm(@view Q′AQ[Ei, Ej], Inf) ≥ atol
+            if end_infnorm[i, j] ≥ threshold
+                # since endomorphism Q′AQ[Ei, Ej] : Ei → Ej is non-zero
+                # it must be an isomorphism, so we merge
                 union!(K, i, j)
             end
         end

--- a/src/partitions.jl
+++ b/src/partitions.jl
@@ -35,20 +35,10 @@ function Partition{T}(M::AbstractMatrix) where {T}
 end
 
 function Partition{T}(M::AbstractMatrix{<:Integer}) where {T}
-    M_vals = unique(M)
-    @assert 0 ≤ first(M_vals)
-    vals = zeros(Int, maximum(M_vals) + 1) # to accomodate for 0 if it exists
-    dim = 0
-    for v in M_vals
-        iszero(v) && continue # to preserve 0
-        dim += 1
-        vals[v+1] = dim
-    end
-    res = zeros(T, size(M))
-    for (v, idx) in zip(M, eachindex(res))
-        res[idx] = vals[v+1]
-    end
-    return Partition{T}(dim, res)
+    P = Partition{T}(0, zeros(T, size(M)))
+    P.matrix .= M
+    P = __sort_unique!(P)
+    return P
 end
 
 function __sort_unique!(P::Partition)

--- a/test/numerical_issues.jl
+++ b/test/numerical_issues.jl
@@ -1,4 +1,3 @@
-using SDPSymmetryReduction
 P = [
     1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64;
     2 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 2 88 89 66 90 68 71 91 92 93 94 84 95 96 97 98 99 100 90 101 72 76 77 102 103 82 81 104 105 106 107 83 94 108 109 93 110 95 111 98;
@@ -66,11 +65,31 @@ P = [
     64 98 172 204 275 305 347 414 466 492 530 567 627 672 693 726 758 811 849 885 919 933 959 984 40 1008 1031 148 1071 251 390 1079 1099 1135 1156 901 1175 1178 1193 1221 1208 1209 1053 1210 442 604 650 1211 1212 829 790 1213 1214 1215 1216 866 1140 1217 1218 1118 1219 1160 1220 1207
 ]
 
-part = SDPSymmetryReduction.Partition(P)
+@testset "numerical issues" begin
 
-c = 0
+    part = SDPSymmetryReduction.Partition(P)
 
-while true
-    @show c = c + 1
-    Qs = SDPSymmetryReduction.diagonalize(Float64, part)
+    function try_fail_eigen_decomposition(part, epsilon, niterates)
+        A = SDPSymmetryReduction.randomize(Float64, part)
+        print("testing for numerical issues ('·'/100it): ")
+        res = niterates, nothing
+        for c in 1:niterates
+            if c % 100 == 0
+                print('·')
+            end
+            try
+                SDPSymmetryReduction.eigen_decomposition(part, A, atol=epsilon)
+            catch err
+                res = niterates, err
+                break
+            end
+        end
+        println(" done!")
+        return res
+    end
+
+    N = 10_000
+    eps = 1e-6
+    res = try_fail_eigen_decomposition(part, eps, N)
+    @test res == (N, nothing)
 end

--- a/test/numerical_issues.jl
+++ b/test/numerical_issues.jl
@@ -80,7 +80,7 @@ P = [
             try
                 SDPSymmetryReduction.eigen_decomposition(part, A, atol=epsilon)
             catch err
-                res = niterates, err
+                res = (c, err)
                 break
             end
         end
@@ -89,7 +89,7 @@ P = [
     end
 
     N = 10_000
-    eps = 1e-6
+    eps = 1e-7
     res = try_fail_eigen_decomposition(part, eps, N)
     @test res == (N, nothing)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,11 +48,10 @@ import CSDP
 
         # cyclic group of order 3:
         C₃ = [
-            1 2 3
-            2 3 1
-            3 1 2
+            1 3 2
+            2 1 3
+            3 2 1
         ]
-        C₃ = reverse(C₃, dims=1)
         P₃ = Partition(C₃)
         @test_throws SDPSymmetryReduction.InvalidDecompositionField blockDiagonalize(P₃)
         @test blockDiagonalize(P₃, complex=true).blkSizes == [1, 1, 1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,4 +63,5 @@ import CSDP
     include("qap.jl")
 
     include("partitions_set.jl")
+    include("numerical_issues.jl")
 end


### PR DESCRIPTION
There're a few small changes:
* use `'` (the `adjoint`) instead of `inv` on each block of `Q'AQ` in `irreducible_decomposition` following later reference of Murota et. al. (see the docstring);
* I refactored the computation of K-partition (of eigenspaces into isomorphism classes) into a standalone function (`isomorphism_partition`);
* There I compute the Inf-norm of each individual endomorphism `Ei → Ej` as a matrix (`block_norms` -- feel free to bike-shed on this name);

Based on those norms we determine which of these endomorphisms are zero and which are isomorphisms.

Now while previously in the last point we used the global `atol` as the threshold, this PR suggests the following method:
1. regard all norms `<atol` as `0`
2. compute a binarisation threshold by dividing all Inf-norms into two groups (clusters) in a progressive manner trying to minimize in-group variance (which is equivalent to maximizing between-group variance). This is so called [Otsu thresholding](https://en.wikipedia.org/wiki/Otsu%27s_method). Here the hidden assumption is that the norms will be bimodal, with both modes following a log-normal distribution and we operate in the log-space.

With this change I can not make the provided example (`test/numerical_issues.jl`) fail, unless I ask for `atol = 1e-5` or larger ;)
